### PR TITLE
Fix for GNU Make 4.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ run:
 run-dev:
 	docker run \
 		--rm \
-		--user $$UID \
+		--user $(shell id -u) \
 		-v `pwd`/care:/app:ro \
 		-v `pwd`/:/work \
 		$(IMAGE) run
@@ -22,7 +22,7 @@ run-treehouse:
 	mkdir -p outputs
 	docker run \
 		--rm \
-		--user $$UID \
+		--user $(shell id -u) \
 		-v `pwd`:/work/rollup:ro \
 		-v `pwd`/manifest.tsv:/work/manifest.tsv:ro \
 		-v `pwd`/outputs:/work/outputs \


### PR DESCRIPTION
Fixes the `docker: invalid reference format: repository name must be lowercase.` error when run on make 4.3 (current version is working ok on  make 3.82).

Replaces `$$UID` with `$(shell id -u)` in the Makefile.

```
$ make run-treehouse COHORT=v11_polya
Running ucsctreehouse/care:0.17.1.0 vs compendium v11_polya
mkdir -p outputs
docker run \
        --rm \
        --user $UID \
        -v `pwd`:/work/rollup:ro \
        -v `pwd`/manifest.tsv:/work/manifest.tsv:ro \
        -v `pwd`/outputs:/work/outputs \
        -v /private/groups/treehouse/archive:/treehouse:ro \
        ucsctreehouse/care:0.17.1.0 pass-args \
                --inputs /treehouse/downstream \
                --cohort /treehouse/compendium/v11_polya \
                --references /treehouse/references
docker: invalid reference format: repository name must be lowercase.
See 'docker run --help'.
make: *** [Makefile:23: run-treehouse] Error 125

$ make --version
GNU Make 4.3
Built for x86_64-pc-linux-gnu

```